### PR TITLE
Handle errors writing files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Breaking changes
 
+## [1.0.0-beta.3]
+### Fixed
+- fix: Use piexijs dump method to detect if file is really supported
+- fix: Error counting amount of files after modifications
+- fix: Handle errors while writing exif info
+
 ## [1.0.0-beta.2]
 ### Fixed
 - Add missing `commander` dependency

--- a/src/exif/fileMethods.js
+++ b/src/exif/fileMethods.js
@@ -28,13 +28,14 @@ async function moveAndWriteExif(filePath, newFilePath, exif) {
   const newImageData = piexif.insert(exifBinary, await getBase64DataFromFile(filePath));
   const fileBuffer = Buffer.from(newImageData, BINARY_FORMAT);
   await ensureDir(dirName(newFilePath));
+  tracer.debug(`Writing exif data to file ${filePath}`);
   return writeFile(newFilePath, fileBuffer);
 }
 
 async function readExifDates(filePath) {
-  tracer.debug(`Reading exif data file ${filePath}`);
+  tracer.debug(`Reading exif data from file ${filePath}`);
   const exif = await readExifFromFile(filePath);
-  tracer.silly(`Exif data`, formatExifToHuman(exif));
+  tracer.silly(`Exif data in ${filePath}`, formatExifToHuman(exif));
   return getDates(exif);
 }
 
@@ -44,9 +45,9 @@ async function moveAndUpdateExifData(filePath, newFilePath, humanPropertiesToMod
     humanPropertiesToModify
   );
   const exif = await readExifFromFile(filePath);
-  tracer.silly(`Exif data from original file`, formatExifToHuman(exif));
+  tracer.silly(`Exif data in original file ${filePath}`, formatExifToHuman(exif));
   const newExif = updateExif(exif, formatHumanToExif(humanPropertiesToModify));
-  tracer.silly(`New exif data`, formatExifToHuman(newExif));
+  tracer.silly(`New exif data for ${newFilePath}`, formatExifToHuman(newExif));
   return moveAndWriteExif(filePath, newFilePath, newExif);
 }
 
@@ -60,7 +61,7 @@ async function moveAndUpdateExifDates(filePath, newFilePath, datesToModify) {
 
 async function isSupportedFile(filePath) {
   try {
-    await readExifFromFile(filePath);
+    piexif.dump(await readExifFromFile(filePath));
     return true;
   } catch (error) {
     return false;

--- a/src/reports/setDates.js
+++ b/src/reports/setDates.js
@@ -221,15 +221,17 @@ class SetDatesReport {
     });
 
     details.forEach((fileReport) => {
-      const fileIsAtSamePath =
-        !fileReport.after.filePath || fileReport.before.filePath === fileReport.after.filePath;
+      const fileIsAtSamePath = fileReport.before.filePath === fileReport.after.filePath;
       if (fileIsAtSamePath) {
         filesKeptAtSamePath++;
       }
       table.addRow(
         formatAll({
           beforeFile: shortPath(toRelative(fileReport.before.filePath)),
-          afterFile: fileIsAtSamePath ? null : shortPath(toRelative(fileReport.after.filePath)),
+          afterFile:
+            !fileReport.after.filePath || fileIsAtSamePath
+              ? null
+              : shortPath(toRelative(fileReport.after.filePath)),
           supported: accent(fileReport.before.supported),
           beforeDate: neutral(fileReport.before.exif.DateTimeOriginal),
           afterDate: strongConditional(fileReport.after.exif.DateTimeOriginal),


### PR DESCRIPTION
### Fixed
- fix: Use piexijs dump method to detect if file is really supported
- fix: Error counting amount of files after modifications
- fix: Handle errors while writing exif info